### PR TITLE
Add a parameter list to EnumElementDecl

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -322,6 +322,8 @@ ERROR(associated_type_generic_parameter_list,PointsToFirstBadToken,
 // Func
 ERROR(func_decl_without_paren,PointsToFirstBadToken,
       "expected '(' in argument list of function declaration", ())
+ERROR(enum_element_decl_without_paren,PointsToFirstBadToken,
+      "expected '(' in argument list of enum element declaration", ())
 ERROR(static_func_decl_global_scope,none,
       "%select{%error|static methods|class methods}0 may only be declared on a type",
       (StaticSpellingKind))

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1021,6 +1021,8 @@ public:
     Subscript,
     /// A curried argument clause.
     Curried,
+    /// An enum element.
+    EnumElement,
   };
 
   /// Parse a parameter-clause.

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -497,7 +497,8 @@ private:
   llvm::Expected<Pattern *> readPattern(DeclContext *owningDC);
 
   ParameterList *readParameterList();
-  
+  ParameterList *maybeReadParameterList();
+
   /// Reads a generic param list from \c DeclTypeCursor.
   ///
   /// If the record at the cursor is not a generic param list, returns null

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 356; // Last change: SILVTable::Entry::Kind
+const uint16_t VERSION_MINOR = 357; // Last change: SE-0155
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -998,11 +998,13 @@ namespace decls_block {
     IdentifierIDField, // name
     DeclContextIDField,// context decl
     TypeIDField, // interface type
-    BCFixed<1>,  // has argument type?
     BCFixed<1>,  // implicit?
     EnumElementRawValueKindField,  // raw value kind
     BCFixed<1>,  // negative raw value?
     BCBlob       // raw value
+
+    // The record is trailed by:
+    // - its argument parameters, if any
   >;
 
   using SubscriptLayout = BCRecordLayout<

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -314,10 +314,8 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   bool visitEnumElementDecl(EnumElementDecl *ED) {
-    if (auto TR = ED->getArgumentTypeLoc().getTypeRepr()) {
-      if (doIt(TR)) {
-        return true;
-      }
+    if (auto *PL = ED->getParameterList()) {
+      visit(PL);
     }
 
     // The getRawValueExpr should remain the untouched original LiteralExpr for

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -774,12 +774,15 @@ void swift::computeDefaultMap(Type type, const ValueDecl *paramOwner,
   // Find the corresponding parameter list.
   const ParameterList *paramList = nullptr;
   if (paramOwner) {
-    if (auto func = dyn_cast<AbstractFunctionDecl>(paramOwner)) {
+    if (auto *func = dyn_cast<AbstractFunctionDecl>(paramOwner)) {
       if (level < func->getNumParameterLists())
         paramList = func->getParameterList(level);
-    } else if (auto subscript = dyn_cast<SubscriptDecl>(paramOwner)) {
+    } else if (auto *subscript = dyn_cast<SubscriptDecl>(paramOwner)) {
       if (level == 1)
         paramList = subscript->getIndices();
+    } else if (auto *enumElement = dyn_cast<EnumElementDecl>(paramOwner)) {
+      if (level == 1)
+        paramList = enumElement->getParameterList();
     }
   }
   

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5114,7 +5114,7 @@ Decl *SwiftDeclConverter::importEnumCase(const clang::EnumConstantDecl *decl,
     rawValueExpr->setNegative(SourceLoc());
 
   auto element = Impl.createDeclWithClangNode<EnumElementDecl>(
-      decl, Accessibility::Public, SourceLoc(), name, TypeLoc(), false,
+      decl, Accessibility::Public, SourceLoc(), name, nullptr,
       SourceLoc(), rawValueExpr, theEnum);
 
   // Give the enum element the appropriate type.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2725,8 +2725,8 @@ public:
     setClangDeclKeywords(EED, Pairs, Builder);
     addLeadingDot(Builder);
     Builder.addTextChunk(EED->getName().str());
-    if (auto argTy = EED->getArgumentInterfaceType())
-      addPatternFromType(Builder, argTy);
+    if (auto *params = EED->getParameterList())
+      addParameters(Builder, params);
 
     // Enum element is of function type such as EnumName.type -> Int ->
     // EnumName; however we should show Int -> EnumName as the type

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5132,17 +5132,14 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
     }
 
     // See if there's a following argument type.
-    ParserResult<TypeRepr> ArgType;
+    ParserResult<ParameterList> ArgType;
+    SmallVector<Identifier, 4> argumentNames;
     if (Tok.isFollowingLParen()) {
-      ArgType = parseTypeTupleBody();
-      if (ArgType.hasCodeCompletion()) {
-        Status.setHasCodeCompletion();
-        return Status;
-      }
-      if (ArgType.isNull()) {
-        Status.setIsParseError();
-        return Status;
-      }
+      DefaultArgumentInfo DefaultArgs(/*inTypeContext*/true);
+      ArgType = parseSingleParameterClause(ParameterContextKind::EnumElement,
+                                           &argumentNames, &DefaultArgs);
+      if (ArgType.isNull() || ArgType.hasCodeCompletion())
+        return ParserStatus(ArgType);
     }
     
     // See if there's a raw value expression.
@@ -5195,10 +5192,8 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
     }
     
     // Create the element.
-    TypeRepr *ArgTR = ArgType.getPtrOrNull();
     auto *result = new (Context) EnumElementDecl(NameLoc, Name,
-                                                 ArgTR,
-                                                 ArgTR != nullptr,
+                                                 ArgType.getPtrOrNull(),
                                                  EqualsLoc,
                                                  LiteralRawValueExpr,
                                                  CurDeclContext);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4510,8 +4510,8 @@ getCallerDefaultArg(ConstraintSystem &cs, DeclContext *dc,
                     SourceLoc loc, ConcreteDeclRef &owner,
                     unsigned index) {
   auto &tc = cs.getTypeChecker();
-  auto ownerFn = cast<AbstractFunctionDecl>(owner.getDecl());
-  auto defArg = ownerFn->getDefaultArg(index);
+
+  auto defArg = getDefaultArgumentInfo(cast<ValueDecl>(owner.getDecl()), index);
   Expr *init = nullptr;
   switch (defArg.first) {
   case DefaultArgumentKind::None:
@@ -4571,7 +4571,8 @@ getCallerDefaultArg(ConstraintSystem &cs, DeclContext *dc,
   }
 
   // Convert the literal to the appropriate type.
-  auto defArgType = ownerFn->mapTypeIntoContext(defArg.second);
+  auto defArgType = owner.getDecl()->getDeclContext()
+                       ->mapTypeIntoContext(defArg.second);
   auto resultTy = tc.typeCheckExpression(
       init, dc, TypeLoc::withoutLoc(defArgType), CTP_CannotFail);
   assert(resultTy && "Conversion cannot fail");

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -933,9 +933,11 @@ namespace {
 
           // The associated data of the case.
           if (level == 1) {
-            auto argTy = enumElt->getArgumentInterfaceType();
-            if (!argTy) return { };
-            gatherArgumentLabels(argTy, scratch);
+            auto *paramList = enumElt->getParameterList();
+            if (!paramList) return { };
+            for (auto param : *paramList) {
+              scratch.push_back(param->getArgumentName());
+            }
             return scratch;
           }
         }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -635,6 +635,9 @@ getCalleeDeclAndArgs(ConstraintSystem &cs,
       } else if (isa<SubscriptDecl>(decl)) {
         // Subscript level 1 == the indices.
         level = 1;
+      } else if (isa<EnumElementDecl>(decl)) {
+        // Enum element level 1 == the payload.
+        level = 1;
       }
     }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -738,8 +738,7 @@ static unsigned getNumRemovedArgumentLabels(TypeChecker &TC, ValueDecl *decl,
   unsigned numParameterLists = 0;
 
   // Enum element with associated value has to be treated
-  // as regular function value and all of the labels have to be
-  // stripped from its parameters.
+  // as regular function value.
   //
   // enum E {
   //   case foo(a: Int)

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -375,8 +375,7 @@ static EnumDecl *synthesizeCodingKeysEnum(TypeChecker &tc,
     // TODO: Ensure the class doesn't already have or inherit a variable named
     // "`super`"; otherwise we will generate an invalid enum. In that case,
     // diagnose and bail.
-    auto *super = new (C) EnumElementDecl(SourceLoc(), C.Id_super, TypeLoc(),
-                                          /*HasArgumentType=*/false,
+    auto *super = new (C) EnumElementDecl(SourceLoc(), C.Id_super, nullptr,
                                           SourceLoc(), nullptr, enumDecl);
     super->setImplicit();
     enumDecl->addMember(super);
@@ -395,9 +394,8 @@ static EnumDecl *synthesizeCodingKeysEnum(TypeChecker &tc,
       case Conforms:
       {
         auto *elt = new (C) EnumElementDecl(SourceLoc(), varDecl->getName(),
-                                            TypeLoc(),
-                                            /*HasArgumentType=*/false,
-                                            SourceLoc(), nullptr, enumDecl);
+                                            nullptr, SourceLoc(), nullptr,
+                                            enumDecl);
         elt->setImplicit();
         enumDecl->addMember(elt);
         break;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -222,7 +222,7 @@ public:
   void visitIndirectAttr(IndirectAttr *attr) {
     if (auto caseDecl = dyn_cast<EnumElementDecl>(D)) {
       // An indirect case should have a payload.
-      if (caseDecl->getArgumentTypeLoc().isNull())
+      if (!caseDecl->hasAssociatedValues())
         TC.diagnose(attr->getLocation(),
                     diag::indirect_case_without_payload, caseDecl->getName());
       // If the enum is already indirect, its cases don't need to be.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1756,7 +1756,9 @@ static void checkTypeAccessibility(
   if (isa<ParamDecl>(context)) {
     context = dyn_cast<AbstractFunctionDecl>(DC);
     if (!context)
-      context = cast<SubscriptDecl>(DC);
+      context = dyn_cast<SubscriptDecl>(DC);
+    if (!context)
+      context = cast<EnumDecl>(DC);
     DC = context->getDeclContext();
   }
 
@@ -2361,20 +2363,23 @@ static void checkAccessibility(TypeChecker &TC, const Decl *D) {
   case DeclKind::EnumElement: {
     auto EED = cast<EnumElementDecl>(D);
 
-    if (!EED->getArgumentTypeLoc().getType())
+    if (!EED->hasAssociatedValues())
       return;
-    checkTypeAccessibility(TC, EED->getArgumentTypeLoc(), EED,
-                           [&](AccessScope typeAccessScope,
-                               const TypeRepr *complainRepr,
-                               DowngradeToWarning downgradeToWarning) {
-      auto typeAccess = typeAccessScope.accessibilityForDiagnostics();
-      auto diagID = diag::enum_case_access;
-      if (downgradeToWarning == DowngradeToWarning::Yes)
-        diagID = diag::enum_case_access_warn;
-      auto diag = TC.diagnose(EED, diagID,
-                              EED->getFormalAccess(), typeAccess);
-      highlightOffendingType(TC, diag, complainRepr);
-    });
+
+    for (auto &P : *EED->getParameterList()) {
+      checkTypeAccessibility(TC, P->getTypeLoc(), P,
+                             [&](AccessScope typeAccessScope,
+                                 const TypeRepr *complainRepr,
+                                 DowngradeToWarning downgradeToWarning) {
+        auto typeAccess = typeAccessScope.accessibilityForDiagnostics();
+        auto diagID = diag::enum_case_access;
+        if (downgradeToWarning == DowngradeToWarning::Yes)
+          diagID = diag::enum_case_access_warn;
+        auto diag = TC.diagnose(EED, diagID,
+                                EED->getFormalAccess(), typeAccess);
+        highlightOffendingType(TC, diag, complainRepr);
+      });
+    }
 
     return;
   }
@@ -6568,12 +6573,17 @@ public:
       
       validateAttributes(TC, EED);
       
-      if (!EED->getArgumentTypeLoc().isNull()) {
-        if (TC.validateType(EED->getArgumentTypeLoc(), EED->getDeclContext(),
-                            TR_EnumCase)) {
+      if (auto *PL = EED->getParameterList()) {
+        GenericTypeToArchetypeResolver resolver(EED->getParentEnum());
+
+        bool isInvalid = TC.typeCheckParameterList(PL, EED->getParentEnum(),
+                                                   TR_EnumCase, resolver);
+
+        if (isInvalid || EED->isInvalid()) {
           EED->setInterfaceType(ErrorType::get(TC.Context));
           EED->setInvalid();
-          return;
+        } else {
+          TC.checkDefaultArguments(PL, EED);
         }
       }
 

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1103,6 +1103,32 @@ recur:
     // Coerce each tuple element to the respective type.
     P->setType(type);
 
+    enum MatchingStrategy_t {
+      NoStrategy,
+      ByTypeLabel,
+      ByVariableName,
+      ByTypeLabelMismatch,
+      ByVariableNameMismatch,
+    };
+
+    auto deriveStrategy = [](const TuplePatternElt &patternElt, const TupleTypeElt &typeElt) {
+      if (!typeElt.getName().empty()) {
+        if (patternElt.getLabel() == typeElt.getName())
+          return ByTypeLabel;
+        else
+          return ByTypeLabelMismatch;
+      }
+
+      if (auto *VP = dyn_cast<VarPattern>(patternElt.getPattern())) {
+        if (VP->getBoundName() == typeElt.getName())
+          return ByVariableName;
+        else
+          return ByVariableNameMismatch;
+      }
+
+      return NoStrategy;
+    };
+
     for (unsigned i = 0, e = TP->getNumElements(); i != e; ++i) {
       TuplePatternElt &elt = TP->getElement(i);
       Pattern *pattern = elt.getPattern();
@@ -1112,10 +1138,10 @@ recur:
         CoercionType = ErrorType::get(Context);
       else
         CoercionType = tupleTy->getElement(i).getType();
-      
+
       // If the tuple pattern had a label for the tuple element, it must match
       // the label for the tuple type being matched.
-      if (!hadError && !elt.getLabel().empty() &&
+      if (!hadError && !tupleTy->getElement(i).getName().empty() &&
           elt.getLabel() != tupleTy->getElement(i).getName()) {
         diagnose(elt.getLabelLoc(), diag::tuple_pattern_label_mismatch,
                  elt.getLabel(), tupleTy->getElement(i).getName());

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1276,6 +1276,9 @@ public:
   void computeAccessibility(ValueDecl *D);
   void computeDefaultAccessibility(ExtensionDecl *D);
 
+  /// Check the default arguments that occur within this value decl.
+  void checkDefaultArguments(ParameterList *params, ValueDecl *VD);
+
   virtual void resolveAccessibility(ValueDecl *VD) override {
     validateAccessibility(VD);
   }
@@ -1788,7 +1791,7 @@ public:
   /// expression to the given context.
   ///
   /// \returns true if any closures were found
-  static bool contextualizeInitializer(Initializer *DC, Expr *init);
+  static bool contextualizeInitializer(DeclContext *DC, Expr *init);
   static void contextualizeTopLevelCode(TopLevelContext &TLC,
                                         ArrayRef<Decl*> topLevelDecls);
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -236,6 +236,52 @@ getActualDefaultArgKind(uint8_t raw) {
   return None;
 }
 
+ParameterList *ModuleFile::maybeReadParameterList() {
+  using namespace decls_block;
+
+  BCOffsetRAII lastRecordOffset(DeclTypeCursor);
+  SmallVector<uint64_t, 8> scratch;
+  StringRef blobData;
+
+  auto next = DeclTypeCursor.advance(AF_DontPopBlockAtEnd);
+  if (next.Kind != llvm::BitstreamEntry::Record)
+    return nullptr;
+
+  unsigned kind = DeclTypeCursor.readRecord(next.ID, scratch, &blobData);
+  if (kind != PARAMETERLIST)
+    return nullptr;
+
+  unsigned numParams;
+  decls_block::ParameterListLayout::readRecord(scratch, numParams);
+
+  SmallVector<ParamDecl*, 8> params;
+  for (unsigned i = 0; i != numParams; ++i) {
+    scratch.clear();
+    auto entry = DeclTypeCursor.advance(AF_DontPopBlockAtEnd);
+    unsigned recordID = DeclTypeCursor.readRecord(entry.ID, scratch);
+    assert(recordID == PARAMETERLIST_ELT);
+    (void) recordID;
+
+    DeclID paramID;
+    bool isVariadic;
+    uint8_t rawDefaultArg;
+    decls_block::ParameterListEltLayout::readRecord(scratch, paramID,
+                                                    isVariadic, rawDefaultArg);
+
+
+    auto decl = cast<ParamDecl>(getDecl(paramID));
+    decl->setVariadic(isVariadic);
+
+    // Decode the default argument kind.
+    // FIXME: Default argument expression, if available.
+    if (auto defaultArg = getActualDefaultArgKind(rawDefaultArg))
+      decl->setDefaultArgumentKind(*defaultArg);
+    params.push_back(decl);
+  }
+
+  return ParameterList::create(getContext(), params);
+}
+
 ParameterList *ModuleFile::readParameterList() {
   using namespace decls_block;
 
@@ -3326,14 +3372,12 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
     IdentifierID nameID;
     DeclContextID contextID;
     TypeID interfaceTypeID;
-    bool hasArgumentType;
     bool isImplicit; bool isNegative;
     unsigned rawValueKindID;
 
     decls_block::EnumElementLayout::readRecord(scratch, nameID,
                                                contextID,
                                                interfaceTypeID,
-                                               hasArgumentType,
                                                isImplicit, rawValueKindID,
                                                isNegative);
 
@@ -3343,8 +3387,7 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
 
     auto elem = createDecl<EnumElementDecl>(SourceLoc(),
                                             getIdentifier(nameID),
-                                            TypeLoc(),
-                                            hasArgumentType,
+                                            maybeReadParameterList(),
                                             SourceLoc(),
                                             nullptr,
                                             DC);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3005,11 +3005,12 @@ void Serializer::writeDecl(const Decl *D) {
                                   addDeclBaseNameRef(elem->getName()),
                                   contextID,
                                   addTypeRef(elem->getInterfaceType()),
-                                  elem->hasAssociatedValues(),
                                   elem->isImplicit(),
                                   (unsigned)RawValueKind,
                                   Negative,
                                   RawValueText);
+    if (auto *PL = elem->getParameterList())
+      writeParameterList(PL);
     break;
   }
 

--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -27,7 +27,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 		case unmap
 
 		/// A custom deallocator
-		case custom(DispatchQueue?, @convention(block) () -> Void)
+		case custom(DispatchQueue?, @convention(block) @escaping () -> Void)
 
 		fileprivate var _deallocator: (DispatchQueue?, @convention(block) () -> Void) {
 			switch self {

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -880,7 +880,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         case none
         
         /// A custom deallocator.
-        case custom((UnsafeMutableRawPointer, Int) -> Void)
+        case custom(@escaping (UnsafeMutableRawPointer, Int) -> Void)
         
         fileprivate var _deallocator : ((UnsafeMutableRawPointer, Int) -> Void) {
 #if DEPLOYMENT_RUNTIME_SWIFT

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -77,7 +77,7 @@ public struct Mirror {
     ///         children: ["someProperty": self.someProperty],
     ///         ancestorRepresentation: .Customized({ super.customMirror })) // <==
     ///     }
-    case customized(() -> Mirror)
+    case customized(@escaping () -> Mirror)
 
     /// Suppress the representation of all ancestor classes.  The
     /// resulting `Mirror`'s `superclassMirror` is `nil`.


### PR DESCRIPTION
This models, but does not plumb through, default arguments.

SE-0155 Requirements:

- [ ] Ban `case Foo()`, rewrite to `case Foo(Void)`
- [ ] Labels in associated value clauses are part of the case name
- [ ] Case name overloading on distinct full names
- [ ] Default arguments in associated value clauses
- [ ] Consistent pattern matching behavior

Further requirements

 - [x] Model associated value clause as a parameter list
- [ ] Type check default argument expressions and contextualize closures within
- [ ] Teach SILGen to emit TupleShuffleExprs into `inject_enum_*` operands