### PR TITLE
Ban empty argument lists in enum element decls

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -870,6 +870,11 @@ WARNING(swift3_unlabeled_parameter_following_variadic_parameter,none,
 ERROR(unlabeled_parameter_following_variadic_parameter,none,
       "a parameter following a variadic parameter requires a label", ())
 
+ERROR(enum_element_empty_arglist,none,
+      "empty enum element argument list must be spelled with 'Void'", ())
+WARNING(enum_element_empty_arglist_swift3,none,
+        "empty enum element argument list must be spelled with 'Void'", ())
+
 //------------------------------------------------------------------------------
 // Statement parsing diagnostics
 //------------------------------------------------------------------------------

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -155,6 +155,21 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
   // Trivial case: empty parameter list.
   if (Tok.is(tok::r_paren)) {
     rightParenLoc = consumeToken(tok::r_paren);
+
+    // Per SE-0155, enum elements may not have empty parameter lists.
+    // Diagnose and insert 'Void' where appropriate.
+    if (paramContext == ParameterContextKind::EnumElement) {
+      decltype(diag::enum_element_empty_arglist) diagnostic;
+      if (Context.isSwiftVersion3()) {
+        diagnostic = diag::enum_element_empty_arglist_swift3;
+      } else {
+        diagnostic = diag::enum_element_empty_arglist;
+      }
+
+      diagnose(leftParenLoc, diagnostic)
+        .highlight({leftParenLoc, rightParenLoc})
+        .fixItInsert(leftParenLoc, "Void");
+    }
     return ParserStatus();
   }
 


### PR DESCRIPTION
SE-0155 Requirements:

- [x] Ban `case Foo()`, rewrite to `case Foo(Void)`
- [ ] Labels in associated value clauses are part of the case name
- [ ] Case name overloading on distinct full names
- [x] Default arguments in associated value clauses
- [ ] Consistent pattern matching behavior

Further requirements

 - [x] Model associated value clause as a parameter list
- [ ] Type check default argument expressions and contextualize closures within
- [ ] Teach SILGen to emit TupleShuffleExprs into `inject_enum_*` operands