### PR TITLE
Allow overloading on the full name of enum cases

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5479,7 +5479,7 @@ class EnumElementDecl : public ValueDecl {
   Expr *TypeCheckedRawValueExpr = nullptr;
   
 public:
-  EnumElementDecl(SourceLoc IdentifierLoc, Identifier Name,
+  EnumElementDecl(SourceLoc IdentifierLoc, DeclName Name,
                   ParameterList *Params,
                   SourceLoc EqualsLoc,
                   LiteralExpr *RawValueExpr,

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -1004,13 +1004,14 @@ namespace decls_block {
 
   using EnumElementLayout = BCRecordLayout<
     ENUM_ELEMENT_DECL,
-    IdentifierIDField, // name
     DeclContextIDField,// context decl
     TypeIDField, // interface type
     BCFixed<1>,  // implicit?
     EnumElementRawValueKindField,  // raw value kind
     BCFixed<1>,  // negative raw value?
-    BCBlob       // raw value
+    IdentifierIDField, // raw value
+    BCVBR<5>, // number of parameter name components
+    BCArray<IdentifierIDField> // name components,
 
     // The record is trailed by:
     // - its argument parameters, if any

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4180,42 +4180,31 @@ void swift::printEnumElementsAsCases(
               return LHS->getNameStr().compare(RHS->getNameStr()) < 0;
             });
 
-  auto printPayloads = [](EnumElementDecl *EE, llvm::raw_ostream &OS) {
+  auto printPayloads = [](ParameterList *PL, llvm::raw_ostream &OS) {
     // If the enum element has no payloads, return.
-    auto TL = EE->getArgumentTypeLoc();
-    if (TL.isNull())
+    if (!PL)
       return;
-    TypeRepr *TR = EE->getArgumentTypeLoc().getTypeRepr();
-    if (auto *TTR = dyn_cast<TupleTypeRepr>(TR)) {
-      SmallVector<Identifier, 4> Names;
-      if (TTR->hasElementNames()) {
-        // Get the name from the tuple repr, if exist.
-        TTR->getElementNames(Names);
+    OS << "(";
+    // Print each element in the pattern match.
+    for (auto i = PL->begin(); i != PL->end(); ++i) {
+      auto *param = *i;
+      if (param->hasName()) {
+        OS << tok::kw_let << " " << param->getName().str();
       } else {
-        // Create same amount of empty names to the elements.
-        Names.assign(TTR->getNumElements(), Identifier());
+        OS << "_";
       }
-      OS << "(";
-      // Print each element in the pattern match.
-      for (unsigned I = 0, N = Names.size(); I < N; I++) {
-        auto Id = Names[I];
-        if (Id.empty())
-          OS << "_";
-        else
-          OS << tok::kw_let << " " << Id.str();
-        if (I + 1 != N) {
-          OS << ", ";
-        }
+      if (i + 1 != PL->end()) {
+        OS << ", ";
       }
-      OS << ")";
     }
+    OS << ")";
   };
 
   // Print each enum element name.
   std::for_each(SortedElements.begin(), SortedElements.end(),
                 [&](EnumElementDecl *EE) {
                   OS << tok::kw_case << " ." << EE->getNameStr();
-                  printPayloads(EE, OS);
+                  printPayloads(EE->getParameterList(), OS);
                   OS << ": " << getCodePlaceholder() << "\n";
                 });
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1648,7 +1648,7 @@ OverloadSignature ValueDecl::getOverloadSignature() const {
   signature.InProtocolExtension
     = getDeclContext()->getAsProtocolExtensionContext();
 
-  // Functions, initializers, and de-initializers include their
+  // Functions, initializers, enum elements, and de-initializers include their
   // interface types in their signatures as well as whether they are
   // instance members.
   if (auto afd = dyn_cast<AbstractFunctionDecl>(this)) {
@@ -1701,6 +1701,9 @@ OverloadSignature ValueDecl::getOverloadSignature() const {
               ->getCanonicalType();
       }
     }
+  } else if (isa<EnumElementDecl>(this)) {
+    signature.InterfaceType = getInterfaceType()->getCanonicalType();
+    signature.IsProperty = true;
   }
 
   return signature;

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -341,21 +341,10 @@ bool NameMatcher::walkToDeclPre(Decl *D) {
     tryResolve(ASTWalker::ParentTy(D), D->getLoc(), LabelRangeType::Param,
                getLabelRanges(SD->getIndices(), getSourceMgr()));
   } else if (EnumElementDecl *EED = dyn_cast<EnumElementDecl>(D)) {
-    if (TupleTypeRepr *TTR = dyn_cast_or_null<TupleTypeRepr>(EED->getArgumentTypeLoc().getTypeRepr())) {
-      size_t ElemIndex = 0;
-      std::vector<CharSourceRange> LabelRanges;
-      for(const TupleTypeReprElement &Elem: TTR->getElements()) {
-        SourceLoc LabelStart(Elem.Type->getStartLoc());
-        SourceLoc LabelEnd(LabelStart);
-
-        auto NameIdentifier = TTR->getElementName(ElemIndex);
-        if (!NameIdentifier.empty()) {
-          LabelStart = TTR->getElementNameLoc(ElemIndex);
-        }
-        LabelRanges.push_back(CharSourceRange(getSourceMgr(), LabelStart, LabelEnd));
-        ++ElemIndex;
-      }
-      tryResolve(ASTWalker::ParentTy(D), D->getLoc(), LabelRangeType::CallArg, LabelRanges);
+    if (auto *ParamList = EED->getParameterList()) {
+      auto LabelRanges = getLabelRanges(ParamList, getSourceMgr());
+      tryResolve(ASTWalker::ParentTy(D), D->getLoc(), LabelRangeType::CallArg,
+                 LabelRanges);
     } else {
       tryResolve(ASTWalker::ParentTy(D), D->getLoc());
     }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5144,14 +5144,14 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
     }
 
     // See if there's a following argument type.
-    ParserResult<ParameterList> ArgType;
+    ParserResult<ParameterList> ArgParams;
     SmallVector<Identifier, 4> argumentNames;
     if (Tok.isFollowingLParen()) {
       DefaultArgumentInfo DefaultArgs(/*inTypeContext*/true);
-      ArgType = parseSingleParameterClause(ParameterContextKind::EnumElement,
+      ArgParams = parseSingleParameterClause(ParameterContextKind::EnumElement,
                                            &argumentNames, &DefaultArgs);
-      if (ArgType.isNull() || ArgType.hasCodeCompletion())
-        return ParserStatus(ArgType);
+      if (ArgParams.isNull() || ArgParams.hasCodeCompletion())
+        return ParserStatus(ArgParams);
     }
     
     // See if there's a raw value expression.
@@ -5203,9 +5203,16 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
       return Status;
     }
     
+    
     // Create the element.
-    auto *result = new (Context) EnumElementDecl(NameLoc, Name,
-                                                 ArgType.getPtrOrNull(),
+    DeclName FullName;
+    if (ArgParams.isNull()) {
+      FullName = Name;
+    } else {
+      FullName = DeclName(Context, Name, argumentNames);
+    }
+    auto *result = new (Context) EnumElementDecl(NameLoc, FullName,
+                                                 ArgParams.getPtrOrNull(),
                                                  EqualsLoc,
                                                  LiteralRawValueExpr,
                                                  CurDeclContext);

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -615,6 +615,21 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
         break;
 
       case CheckInput: {
+        if (auto *ED1 = dyn_cast<EnumElementDecl>(decl1)) {
+          if (auto *ED2 = dyn_cast<EnumElementDecl>(decl2)) {
+            assert(ED1->hasAssociatedValues() || ED2->hasAssociatedValues());
+
+            // If the first function has fewer effective parameters than the
+            // second, it is more specialized.
+            if (!ED1->hasAssociatedValues() && ED2->hasAssociatedValues())
+              return true;
+            if (ED1->hasAssociatedValues() && !ED2->hasAssociatedValues())
+              return false;
+
+            // Else, fall through to compare function type specialization.
+          }
+        }
+
         // Check whether the first function type's input is a subtype of the
         // second type's inputs, i.e., can we forward the arguments?
         auto funcTy1 = openedType1->castTo<FunctionType>();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2369,7 +2369,7 @@ static void checkAccessControl(TypeChecker &TC, const Decl *D) {
                              [&](AccessScope typeAccessScope,
                                  const TypeRepr *complainRepr,
                                  DowngradeToWarning downgradeToWarning) {
-        auto typeAccess = typeAccessScope.accessibilityForDiagnostics();
+        auto typeAccess = typeAccessScope.accessLevelForDiagnostics();
         auto diagID = diag::enum_case_access;
         if (downgradeToWarning == DowngradeToWarning::Yes)
           diagID = diag::enum_case_access_warn;
@@ -4370,9 +4370,9 @@ public:
       }
       {
         // Check for duplicate enum members.
-        llvm::DenseMap<Identifier, EnumElementDecl *> Elements;
+        llvm::DenseMap<DeclName, EnumElementDecl *> Elements;
         for (auto *EED : ED->getAllElements()) {
-          auto Res = Elements.insert({ EED->getName(), EED });
+          auto Res = Elements.insert({ EED->getFullName(), EED });
           if (!Res.second) {
             EED->setInterfaceType(ErrorType::get(TC.Context));
             EED->setInvalid();

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1141,12 +1141,12 @@ recur:
 
       // If the tuple pattern had a label for the tuple element, it must match
       // the label for the tuple type being matched.
-      if (!hadError && !tupleTy->getElement(i).getName().empty() &&
-          elt.getLabel() != tupleTy->getElement(i).getName()) {
-        diagnose(elt.getLabelLoc(), diag::tuple_pattern_label_mismatch,
-                 elt.getLabel(), tupleTy->getElement(i).getName());
-        hadError = true;
-      }
+//      if (!hadError && !tupleTy->getElement(i).getName().empty() &&
+//          elt.getLabel() != tupleTy->getElement(i).getName()) {
+//        diagnose(elt.getLabelLoc(), diag::tuple_pattern_label_mismatch,
+//                 elt.getLabel(), tupleTy->getElement(i).getName());
+//        hadError = true;
+//      }
       
       hadError |= coercePatternToType(pattern, dc, CoercionType,
                                       options, resolver);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1280,7 +1280,7 @@ public:
   void checkDefaultArguments(ParameterList *params, ValueDecl *VD);
 
   virtual void resolveAccessControl(ValueDecl *VD) override {
-    validateAccessibility(VD);
+    validateAccessControl(VD);
   }
 
   virtual void resolveDeclSignature(ValueDecl *VD) override {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3387,24 +3387,43 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
   }
 
   case decls_block::ENUM_ELEMENT_DECL: {
-    IdentifierID nameID;
     DeclContextID contextID;
     TypeID interfaceTypeID;
     bool isImplicit; bool isNegative;
     unsigned rawValueKindID;
+    IdentifierID blobData;
+    unsigned numArgNames;
+    ArrayRef<uint64_t> argNameAndDependencyIDs;
 
-    decls_block::EnumElementLayout::readRecord(scratch, nameID,
-                                               contextID,
+    decls_block::EnumElementLayout::readRecord(scratch, contextID,
                                                interfaceTypeID,
                                                isImplicit, rawValueKindID,
-                                               isNegative);
+                                               isNegative,
+                                               blobData,
+                                               numArgNames,
+                                               argNameAndDependencyIDs);
+
+    // Resolve the name ids.
+    Identifier baseName = getIdentifier(argNameAndDependencyIDs.front());
+    SmallVector<Identifier, 2> argNames;
+    for (auto argNameID : argNameAndDependencyIDs.slice(1, numArgNames-1))
+      argNames.push_back(getIdentifier(argNameID));
+    DeclName name(ctx, baseName, argNames);
+
+    for (TypeID dependencyID : argNameAndDependencyIDs.slice(numArgNames+1)) {
+      auto dependency = getTypeChecked(dependencyID);
+      if (!dependency) {
+        return llvm::make_error<TypeError>(
+          name, takeErrorInfo(dependency.takeError()));
+      }
+    }
 
     DeclContext *DC = getDeclContext(contextID);
     if (declOrOffset.isComplete())
       return declOrOffset;
 
     auto elem = createDecl<EnumElementDecl>(SourceLoc(),
-                                            getIdentifier(nameID),
+                                            name,
                                             maybeReadParameterList(),
                                             SourceLoc(),
                                             nullptr,
@@ -3416,8 +3435,8 @@ ModuleFile::getDeclChecked(DeclID DID, Optional<DeclContext *> ForcedContext) {
     case EnumElementRawValueKind::None:
       break;
     case EnumElementRawValueKind::IntegerLiteral: {
-      auto literalText = getContext().AllocateCopy(blobData);
-      auto literal = new (getContext()) IntegerLiteralExpr(literalText,
+      auto literalText = getIdentifier(blobData);
+      auto literal = new (getContext()) IntegerLiteralExpr(literalText.get(),
                                                            SourceLoc(),
                                                            /*implicit*/ true);
       if (isNegative)

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2999,28 +2999,38 @@ void Serializer::writeDecl(const Decl *D) {
     auto elem = cast<EnumElementDecl>(D);
     auto contextID = addDeclContextRef(elem->getDeclContext());
 
+    SmallVector<IdentifierID, 4> nameComponentsAndDependencies;
+    nameComponentsAndDependencies.push_back(addDeclBaseNameRef(elem->getBaseName()));
+    for (auto argName : elem->getFullName().getArgumentNames())
+      nameComponentsAndDependencies.push_back(addDeclBaseNameRef(argName));
+
+    Type ty = elem->getInterfaceType();
+    for (Type dependency : collectDependenciesFromType(ty->getCanonicalType()))
+      nameComponentsAndDependencies.push_back(addTypeRef(dependency));
+
     // We only serialize the raw values of @objc enums, because they're part
     // of the ABI. That isn't the case for Swift enums.
     auto RawValueKind = EnumElementRawValueKind::None;
     bool Negative = false;
-    StringRef RawValueText;
+    Identifier RawValueText;
     if (elem->getParentEnum()->isObjC()) {
       // Currently ObjC enums always have integer raw values.
       RawValueKind = EnumElementRawValueKind::IntegerLiteral;
       auto ILE = cast<IntegerLiteralExpr>(elem->getRawValueExpr());
-      RawValueText = ILE->getDigitsText();
+      RawValueText = M->getASTContext().getIdentifier(ILE->getDigitsText());
       Negative = ILE->isNegative();
     }
 
     unsigned abbrCode = DeclTypeAbbrCodes[EnumElementLayout::Code];
     EnumElementLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                                  addDeclBaseNameRef(elem->getName()),
                                   contextID,
                                   addTypeRef(elem->getInterfaceType()),
                                   elem->isImplicit(),
                                   (unsigned)RawValueKind,
                                   Negative,
-                                  RawValueText);
+                                  addDeclBaseNameRef(RawValueText),
+                                  elem->getFullName().getArgumentNames().size()+1,
+                                  nameComponentsAndDependencies);
     if (auto *PL = elem->getParameterList())
       writeParameterList(PL);
     break;


### PR DESCRIPTION
SE-0155 Requirements:

- [x] Ban `case Foo()`, rewrite to `case Foo(Void)`
- [x] Labels in associated value clauses are part of the case name
- [x] Case name overloading on distinct full names
- [x] Default arguments in associated value clauses
- [ ] Consistent pattern matching behavior

Further requirements

 - [x] Model associated value clause as a parameter list
- [ ] Type check default argument expressions and contextualize closures within
- [ ] Teach SILGen to emit TupleShuffleExprs into `inject_enum_*` operands
- [ ] Update the SIL verifier to only check arguments, not labels.